### PR TITLE
Accept test selection regex on :GoDebugTest

### DIFF
--- a/plugin/godebug.vim
+++ b/plugin/godebug.vim
@@ -69,7 +69,17 @@ endfunction
 
 function! godebug#debugtest(bang, ...) abort
   call godebug#writeBreakpointsFile()
-  return go#term#new(a:bang, ["dlv", "test", "--init=" . g:godebug_breakpoints_file])
+
+  let command = ["dlv", "test", "--init=" . g:godebug_breakpoints_file]
+
+  " if the user provides an argument use it as the test selection regex
+  if a:0 > 1
+    let test_regex = a:2
+    let go_test_args = ["--", "-test.run", test_regex]
+    let command += go_test_args
+  endif
+
+  return go#term#new(a:bang, command)
 endfunction
 
 command! -nargs=* -bang GoToggleBreakpoint call godebug#toggleBreakpoint(expand('%:p'), line('.'), <f-args>)


### PR DESCRIPTION
Source file
```go
package main

import "testing"

func TestFailure(t *testing.T) {
	t.Fatal("not implemented")
}

func TestHelloWorld(t *testing.T) {
}

```

`:GoDebugTest`
```
Type 'help' for list of commands.
--- FAIL: TestFailure (0.00s)
        main_test.go:6: not implemented
FAIL
/Users/nathan/.cache/nvim/vim-godebug/63271502391631:1: Process 6470 has exited with status 1
(dlv)
```
`:GoDebugTest TestHelloWorld `
```
Type 'help' for list of commands.
PASS
/Users/nathan/.cache/nvim/vim-godebug/63271502391631:1: Process 6565 has exited with status 0
(dlv)

```