### PR TITLE
allow customizing the gutter sign

### DIFF
--- a/plugin/godebug.vim
+++ b/plugin/godebug.vim
@@ -29,6 +29,12 @@ call mkdir(g:godebug_cache_path, "p")
 " create a reasonably unique breakpoints file path per vim instance
 let g:godebug_breakpoints_file = g:godebug_cache_path . "/". getpid() . localtime()
 
+" allow customizing the gutter sign
+if !exists("g:godebug_breakpoints_sign")
+  let g:godebug_breakpoints_sign="◉"
+endif
+highlight default link GoDebugBreakpointsSign Search
+
 autocmd VimLeave * call godebug#deleteBreakpointsFile()<cr>
 
 " Private functions {{{1
@@ -38,7 +44,7 @@ function! godebug#toggleBreakpoint(file, line, ...) abort
   let breakpoint = "break " . a:file. ':' . a:line
 
   " Define the sign for the gutter
-  exe "sign define gobreakpoint text=◉ texthl=Search"
+  exe "sign define gobreakpoint text=" . g:godebug_breakpoints_sign . " texthl=GoDebugBreakpointsSign"
 
   " If the line isn't already in the list, add it.
   " Otherwise remove it from the list.


### PR DESCRIPTION
These changes allow an end-user to customize the breakpoint sign, for example by placing the following in `config.vim`:

```vim
let g:godebug_breakpoints_sign = '✽'
hi GoDebugBreakpointsSign ctermfg=239 ctermbg=235
```